### PR TITLE
Added array support

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -35,6 +35,10 @@ final class Container implements ContainerInterface, ServiceProviderInterface
 
             /* @var $args array */
             $args = array_map(function($row) use($app) {
+                if (!is_numeric($row) && !is_string($row)) {
+                    return $row;
+                }
+
                 if ($app->offsetExists($row)) {
                     return $app[$row];
                 }

--- a/tests/Di/ContainerTest.php
+++ b/tests/Di/ContainerTest.php
@@ -80,4 +80,15 @@ class ContainerTest extends PHPUnit_Framework_TestCase
 
          $this->assertEquals($name, $result);
      }
+
+     /**
+      * @test
+      */
+      public function getParametersFromFooTwo()
+      {
+          $expected = ["param1" => "hello", "param2" => "world"];
+          $result   = $this->app['service.foo-two']->getParameters();
+
+          $this->assertEquals($expected, $result);
+      }
 }

--- a/tests/Resources/FooTwo.php
+++ b/tests/Resources/FooTwo.php
@@ -14,11 +14,18 @@ class FooTwo
     private $name;
 
     /**
-     * @param mixed $name
+     * @var array
      */
-    public function __construct($name = null)
+    private $parameters;
+
+    /**
+     * @param mixed $name
+     * @param array $parameters
+     */
+    public function __construct($name = null, array $parameters)
     {
         $this->name = $name;
+        $this->parameters = $parameters;
     }
 
     /**
@@ -27,5 +34,10 @@ class FooTwo
     public function getName()
     {
         return $this->name;
+    }
+
+    public function getParameters()
+    {
+        return $this->parameters;
     }
 }

--- a/tests/Resources/di.yml
+++ b/tests/Resources/di.yml
@@ -10,4 +10,6 @@ services:
   service.foo-two:
     - \SilexFriends\Tests\Resources\FooTwo
     - 'hello'
-
+    -
+      param1: 'hello'
+      param2: 'world'


### PR DESCRIPTION
Since the `$app` container only accepts string or integer keys, we might want to return the original row in case it's not Int or String.
